### PR TITLE
fix creating list when only one li is selected by user

### DIFF
--- a/src/DOM.js
+++ b/src/DOM.js
@@ -326,6 +326,15 @@ angular.module('textAngular.DOM', ['textAngular.factories'])
                 //console.log('PPPPPPPPPPPPP', tagName, selfTag, selectedElements, tagName.match(BLOCKELEMENTS), $selected.hasClass('ta-bind'), $selected.parent()[0].tagName);
                 if (selectedElements.length>1 && (tagName === 'ol' ||  tagName === 'ul' )) {
                     return listElementsToSelfTag($selected, selectedElements, selfTag, selfTag===tagName, taDefaultWrap);
+                } else if (tagName === 'li' && $selected.parent().children().length > 1) {
+                    // if list has more than one elements and only one of them is selected
+                    var parent = $selected.parent();
+                    if (parent.length > 0 && parent[0].tagName) {
+                        var parentTagName = parent[0].tagName.toLowerCase();
+                        if (parentTagName === 'ol' || parentTagName === 'ul') {
+                            return listElementsToSelfTag(parent, [selectedElement], selfTag, parentTagName, taDefaultWrap);
+                        }
+                    }
                 }
                 if(tagName === selfTag){
                     // if all selected then we should remove the list


### PR DESCRIPTION
Fixes the problem that when user set cursor to one line of list and clicked multiple times on list button it lead to creation of nested lists and duplicated elements.